### PR TITLE
Fix README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ Tests are automatically run on Windows, MacOS and Linux for every pull request.
 And build warnings will break the build.
 
 If you are having trouble debugging a test that is failing for a platform you
-don't have access to please us know.
+don't have access to please let us know.
 
 Thanks to [Gitpod](https://gitpod.io/) there is a really easy way of creating
 a ready to go development environment with VS Code. You can open a Gitpod


### PR DESCRIPTION
## Summary
- fix typo in README

## Testing
- `dotnet test --no-build` *(fails: The argument ... is invalid)*

------
https://chatgpt.com/codex/tasks/task_e_6856d115bf4c8333bbdd64cc41b433b6