### PR TITLE
Fix README heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ access token and provide this, and your username, when running CycloneDX.
 
 To generate a token go to
 [Personal access tokens](https://github.com/settings/tokens) under
-`Settings / Developer setings`. From there select the option to
+`Settings / Developer settings`. From there, select the option to
 [Generate new token](https://github.com/settings/tokens/new). No special token
 permissions are required.
 


### PR DESCRIPTION
## Summary
- fix developer settings heading in the README
- clarify wording

## Testing
- `dotnet test` *(fails: unable to load nuget packages)*

------
https://chatgpt.com/codex/tasks/task_e_6856d1ce1ec8833397a5530d84fa05ec