### PR TITLE
Add AGENTS instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,17 @@
+# AGENT INSTRUCTIONS
+
+This repository uses .NET 8 and .NET 9. Before committing changes run the following commands:
+
+```bash
+dotnet build /WarnAsError
+dotnet test
+```
+
+Ensure added features have accompanying tests. Build warnings should be treated as errors. Formatting is controlled by `.editorconfig`:
+
+- C# files use four spaces for indentation.
+- JSON, YAML and XML files use two spaces.
+- Trim trailing whitespace (except in Markdown).
+- End files with a newline.
+
+Refer to `README.md` for additional development details.


### PR DESCRIPTION
## Summary
- add `AGENTS.md` at repo root to document build and test steps

## Testing
- `dotnet build /WarnAsError` *(fails: Unable to load the service index)*
- `dotnet test` *(fails: Unable to load the service index)*

------
https://chatgpt.com/codex/tasks/task_e_6856d549b6188333a012d696e2a0cf2b