### PR TITLE
Support version from project file

### DIFF
--- a/CycloneDX.Tests/FunctionalTests/FunctionalTestHelper.cs
+++ b/CycloneDX.Tests/FunctionalTests/FunctionalTestHelper.cs
@@ -68,6 +68,19 @@ namespace CycloneDX.Tests.FunctionalTests
             return await Test(options, nugetService, mockFileSystem, expectedExitCode).ConfigureAwait(false);
         }
 
+        public static async Task<Bom> TestWithProjectFile(string assetsJson, string projectFileContents, RunOptions options, INugetServiceFactory nugetService = null, ExitCode expectedExitCode = ExitCode.OK)
+        {
+            nugetService ??= CreateMockNugetServiceFactory();
+
+            var mockFileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { MockUnixSupport.Path("c:/ProjectPath/Project.csproj"), new MockFileData(projectFileContents) },
+                { MockUnixSupport.Path("c:/ProjectPath/obj/project.assets.json"), new MockFileData(assetsJson) }
+            });
+
+            return await Test(options, nugetService, mockFileSystem, expectedExitCode).ConfigureAwait(false);
+        }
+
 
         public static async Task<Bom> Test(RunOptions options, MockFileSystem mockFileSystem,
             ExitCode expectedExitCode = ExitCode.OK) => await Test(options, CreateMockNugetServiceFactory(),

--- a/CycloneDX.Tests/FunctionalTests/ProjectFileVersionMetadata.cs
+++ b/CycloneDX.Tests/FunctionalTests/ProjectFileVersionMetadata.cs
@@ -1,0 +1,24 @@
+using System.IO;
+using System.Threading.Tasks;
+using CycloneDX.Models;
+using Xunit;
+
+namespace CycloneDX.Tests.FunctionalTests
+{
+    public class ProjectFileVersionMetadata
+    {
+        [Fact(Timeout = 15000)]
+        public async Task MetadataVersionFromProjectFile()
+        {
+            var assetsJson = File.ReadAllText(Path.Combine("FunctionalTests", "TestcaseFiles", "SimpleNETStandardLibrary.json"));
+            var options = new RunOptions
+            {
+            };
+
+            var csproj = "<Project Sdk=\"Microsoft.NET.Sdk\">\n  <PropertyGroup>\n    <OutputType>Exe</OutputType>\n    <PackageId>SampleProject</PackageId>\n  <Version>1.2.3</Version>\n  </PropertyGroup>\n  <ItemGroup>\n  </ItemGroup>\n</Project>\n";
+
+            var bom = await FunctionalTestHelper.TestWithProjectFile(assetsJson, csproj, options);
+            Assert.Equal("1.2.3", bom.Metadata.Component.Version);
+        }
+    }
+}

--- a/CycloneDX/Interfaces/IProjectFileService.cs
+++ b/CycloneDX/Interfaces/IProjectFileService.cs
@@ -29,6 +29,7 @@ namespace CycloneDX.Interfaces
         Task<HashSet<DotnetDependency>> RecursivelyGetProjectDotnetDependencysAsync(string projectFilePath, string baseIntermediateOutputPath, bool excludeTestProjects, string framework, string runtime);
         Task<HashSet<DotnetDependency>> RecursivelyGetProjectReferencesAsync(string projectFilePath);
         Component GetComponent(DotnetDependency dotnetDependency);
+        (string name, string version) GetAssemblyNameAndVersion(string projectFilePath);
         bool IsTestProject(string projectFilePath);
     }
 }

--- a/CycloneDX/Runner.cs
+++ b/CycloneDX/Runner.cs
@@ -184,6 +184,14 @@ namespace CycloneDX
                     }
                     packages = await projectFileService.RecursivelyGetProjectDotnetDependencysAsync(fullSolutionOrProjectFilePath, baseIntermediateOutputPath, excludetestprojects, framework, runtime).ConfigureAwait(false);
                     topLevelComponent.Name = fileSystem.Path.GetFileNameWithoutExtension(SolutionOrProjectFile);
+                    if (string.IsNullOrEmpty(setVersion))
+                    {
+                        var (_, projectVersion) = projectFileService.GetAssemblyNameAndVersion(fullSolutionOrProjectFilePath);
+                        if (!string.IsNullOrEmpty(projectVersion))
+                        {
+                            topLevelComponent.Version = projectVersion;
+                        }
+                    }
                 }
                 else if (Utils.IsSupportedProjectType(SolutionOrProjectFile))
                 {
@@ -194,6 +202,14 @@ namespace CycloneDX
                     }
                     packages = await projectFileService.GetProjectDotnetDependencysAsync(fullSolutionOrProjectFilePath, baseIntermediateOutputPath, excludetestprojects, framework, runtime).ConfigureAwait(false);
                     topLevelComponent.Name = fileSystem.Path.GetFileNameWithoutExtension(SolutionOrProjectFile);
+                    if (string.IsNullOrEmpty(setVersion))
+                    {
+                        var (_, projectVersion) = projectFileService.GetAssemblyNameAndVersion(fullSolutionOrProjectFilePath);
+                        if (!string.IsNullOrEmpty(projectVersion))
+                        {
+                            topLevelComponent.Version = projectVersion;
+                        }
+                    }
                 }
                 else if (fileSystem.Path.GetFileName(SolutionOrProjectFile).ToLowerInvariant().Equals("packages.config", StringComparison.OrdinalIgnoreCase))
                 {

--- a/CycloneDX/Services/ProjectFileService.cs
+++ b/CycloneDX/Services/ProjectFileService.cs
@@ -81,7 +81,7 @@ namespace CycloneDX.Services
             return testProjectPropertyGroup != null;
         }
 
-        private (string name, string version) GetAssemblyNameAndVersion(string projectFilePath)
+        public (string name, string version) GetAssemblyNameAndVersion(string projectFilePath)
         {
             if (!_fileSystem.File.Exists(projectFilePath))
             {
@@ -111,7 +111,7 @@ namespace CycloneDX.Services
 
             // Extract Version
             XmlElement versionElement = xmldoc.SelectSingleNode("/Project/PropertyGroup/Version") as XmlElement;
-            string version = versionElement?.Value;
+            string version = versionElement?.InnerText;
 
             if (version == null)
             {


### PR DESCRIPTION
## Summary
- use csproj version if metadata version isn't set
- expose assembly name and version from `ProjectFileService`
- test reading version from project file

## Testing
- ❌ `dotnet test -v minimal` *(failed: Codex couldn't run certain commands due to environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_6856d841a69083338d142fa282f07932